### PR TITLE
Fix: in some cases, the baseline is not shown

### DIFF
--- a/elevation-profile.ts
+++ b/elevation-profile.ts
@@ -62,8 +62,6 @@ export default class ElevationProfile extends LitElement {
   private meterFormat: Intl.NumberFormat | null = null;
   private kilometerFormat: Intl.NumberFormat | null = null;
 
-  private lowestY: number | undefined;
-
   override updated(changedProperties: PropertyValues) {
     if (changedProperties.has('locale')) {
       this.meterFormat = new Intl.NumberFormat(this.locale, {
@@ -86,8 +84,6 @@ export default class ElevationProfile extends LitElement {
         this.plotData.push(...simplify(data, this.tolerance));
         this.plotData.push({x: line[line.length - 1][3], y: NaN, coordinate: []});
       }
-      this.lowestY = this.plotData.length && this.plotData
-          .reduce((a, b) => !isNaN(b.y) ? Math.min(a, b.y) : a, this.plotData[0].y);
 
       this.scaleX.domain(extent(this.plotData, (data: PlotPoint) => data.x));
       this.scaleY.domain(extent(this.plotData, (data: PlotPoint) => data.y)).nice();
@@ -125,8 +121,7 @@ export default class ElevationProfile extends LitElement {
     select(this.querySelector('.grid.x')).call(this.xGrid);
     select(this.querySelector('.grid.y')).call(this.yGrid);
 
-
-    const firstYTick = this.scaleY.ticks(yTicks)[0];
+    const offset = this.yGrid.offset();
 
     return svg`
       <svg width="${width}" height="${height}" xmlns="http://www.w3.org/2000/svg">
@@ -167,9 +162,9 @@ export default class ElevationProfile extends LitElement {
           @pointerout="${this.pointerOut}"
         />
         <g 
-          transform="translate(${this.margin.left},${height - this.margin.bottom})"
+          transform="translate(${this.margin.left},${height - this.margin.bottom + offset})"
           class="axis"
-          style="visibility: ${this.lowestY && firstYTick >= this.lowestY ? 'visible' : 'hidden'}">
+          style="visibility: ${this.lines.length ? 'visible' : 'hidden'}">
           <line x2="${width - this.margin.left - this.margin.right}"></line>
         </g>
       </svg>


### PR DESCRIPTION
I updated the way how baseline works. Now it is always shown, and when we have a grid line on the same positions it overlaps because there is no way to check if we have a grid line as a baseline for all possible cases.