### PR TITLE
chore: fix TypeScript 6 type errors with d3 modules

### DIFF
--- a/elevation-profile.ts
+++ b/elevation-profile.ts
@@ -7,12 +7,13 @@ import type {PropertyValues, TemplateResult} from 'lit';
 
 import {extent, bisector} from 'd3-array';
 import {scaleLinear} from 'd3-scale';
+import type {ScaleLinear} from 'd3-scale';
 import {line, area} from 'd3-shape';
 import {axisBottom, axisLeft} from 'd3-axis';
 import {select, pointer} from 'd3-selection';
 
 // FIXME: use simplify to reduce number of points based on tolerance
-import simplify from './simplify.js';
+// import simplify from './simplify.js';
 
 type PlotPoint = {
   x: number;
@@ -37,7 +38,7 @@ export default class ElevationProfile extends LitElement {
   @property({type: String}) locale = navigator.language;
   @property({type: Array}) lines: number[][][] = [];
   @property({type: Array}) points: number[][] = [];
-  @property() updateScale = (x: scaleLinear, y: scaleLinear, width: number, height: number): void => {};
+  @property() updateScale = (x: ScaleLinear<number, number>, y: ScaleLinear<number, number>, width: number, height: number): void => {};
   @property({type: Object}) margin = {top: 20, right: 20, bottom: 20, left: 20};
   @property({type: Object}) tickSize = {x: 100, y: 40};
   @property({type: Boolean}) pointerEvents = true;
@@ -60,16 +61,16 @@ export default class ElevationProfile extends LitElement {
 
   private bisectDistance = bisector((point: PlotPoint) => point.x);
 
-  private line = line()
-    .defined((point: PlotPoint) => !isNaN(point.y))
-    .x((point: PlotPoint) => this.scaleX(point.x))
-    .y((point: PlotPoint) => this.scaleY(point.y));
-  private area = area()
-    .defined((point: PlotPoint) => !isNaN(point.y))
-    .x((point: PlotPoint) => this.scaleX(point.x))
-    .y1((point: PlotPoint) => this.scaleY(point.y));
-  private xAxis = axisBottom(this.scaleX).tickFormat((value: number) => this.tickFormat(value, 'x'));
-  private yAxis = axisLeft(this.scaleY).tickFormat((value: number) => this.tickFormat(value, 'y'));
+  private line = line<PlotPoint>()
+    .defined((point) => !isNaN(point.y))
+    .x((point) => this.scaleX(point.x))
+    .y((point) => this.scaleY(point.y));
+  private area = area<PlotPoint>()
+    .defined((point) => !isNaN(point.y))
+    .x((point) => this.scaleX(point.x))
+    .y1((point) => this.scaleY(point.y));
+  private xAxis = axisBottom(this.scaleX).tickFormat((value) => this.tickFormat(+value, 'x'));
+  private yAxis = axisLeft(this.scaleY).tickFormat((value) => this.tickFormat(+value, 'y'));
   private xGrid = axisBottom(this.scaleX).tickFormat(() => '');
   private yGrid = axisLeft(this.scaleY).tickFormat(() => '');
 
@@ -104,8 +105,8 @@ export default class ElevationProfile extends LitElement {
          }
        });
 
-      this.scaleX.domain(extent(this.plotData, (data: PlotPoint) => data.x));
-      this.scaleY.domain(extent(this.plotData, (data: PlotPoint) => data.y));
+      this.scaleX.domain(extent(this.plotData, (data: PlotPoint) => data.x) as [number, number]);
+      this.scaleY.domain(extent(this.plotData, (data: PlotPoint) => data.y) as [number, number]);
 
       this.updateScale(this.scaleX, this.scaleY, this.offsetWidth, this.offsetHeight);
     }
@@ -143,10 +144,10 @@ export default class ElevationProfile extends LitElement {
     this.yAxis.ticks(yTicks);
     this.yGrid.ticks(yTicks);
 
-    select(this.querySelector('.axis.x')).call(this.xAxis);
-    select(this.querySelector('.axis.y')).call(this.yAxis);
-    select(this.querySelector('.grid.x')).call(this.xGrid);
-    select(this.querySelector('.grid.y')).call(this.yGrid);
+    select(this.querySelector<SVGGElement>('.axis.x')!).call(this.xAxis);
+    select(this.querySelector<SVGGElement>('.axis.y')!).call(this.yAxis);
+    select(this.querySelector<SVGGElement>('.grid.x')!).call(this.xGrid);
+    select(this.querySelector<SVGGElement>('.grid.y')!).call(this.yGrid);
 
     const offset = this.yGrid.offset();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,11 @@
         "@parcel/packager-ts": "2.16.4",
         "@parcel/transformer-typescript-tsc": "2.16.4",
         "@parcel/transformer-typescript-types": "2.16.4",
+        "@types/d3-array": "3.2.2",
+        "@types/d3-axis": "3.0.6",
+        "@types/d3-scale": "4.0.9",
+        "@types/d3-selection": "3.0.11",
+        "@types/d3-shape": "3.1.8",
         "gh-pages": "6.3.0",
         "parcel": "2.16.4",
         "typescript": "6.0.2"
@@ -2329,6 +2334,64 @@
       "dependencies": {
         "@swc/counter": "^0.1.3"
       }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "prepack": "npm run build",
     "build": "rm -rf dist && parcel build",
     "build-demo": "parcel build --target demo index.html",
-    "publish-demo": "rm -rf build && npm run build-demo && gh-pages -d build"
+    "publish-demo": "rm -rf build && npm run build-demo && gh-pages -d build",
+    "typecheck": "tsc --pretty --noEmit"
   },
   "dependencies": {
     "@lit-labs/observers": "2.1.0",
@@ -41,6 +42,11 @@
     "@parcel/packager-ts": "2.16.4",
     "@parcel/transformer-typescript-tsc": "2.16.4",
     "@parcel/transformer-typescript-types": "2.16.4",
+    "@types/d3-array": "3.2.2",
+    "@types/d3-axis": "3.0.6",
+    "@types/d3-scale": "4.0.9",
+    "@types/d3-selection": "3.0.11",
+    "@types/d3-shape": "3.1.8",
     "gh-pages": "6.3.0",
     "parcel": "2.16.4",
     "typescript": "6.0.2"


### PR DESCRIPTION
- Add @types/d3-* devDependencies for d3-array, d3-axis, d3-scale, d3-selection, d3-shape
- Use ScaleLinear<number, number> type for updateScale property
- Parameterize line<PlotPoint> and area<PlotPoint> generics
- Fix tickFormat callbacks using +value coercion for NumberValue
- Cast extent() result to [number, number] to satisfy domain()
- Use querySelector<SVGGElement> with non-null assertion for d3 select/call
- Comment out unused simplify import